### PR TITLE
Updated the swift version of docker to 5.3.3-focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.3.1-focal as builder
+FROM swift:5.3.3-focal as builder
 WORKDIR /opt/feather
 
 COPY . .
@@ -76,7 +76,7 @@ RUN chmod 550 /opt/feather/bin/Feather
 
 
 ## Slim version of the container
-FROM swift:5.3.1-focal-slim
+FROM swift:5.3.3-focal-slim
 WORKDIR /var/feather
 COPY --from=builder /opt/feather /opt/feather
 


### PR DESCRIPTION
Hello @tib,

Is aw there is a build failure on docker. This is due to an issue in swift linux with the date which was fix in 5.3.3.

[DockerHub Build in 'main' (d51ade1b)](https://hub.docker.com/repository/registry-1.docker.io/feathercms/feathercms/builds/ff37fd42-7725-40de-b498-553e3ef54fe8)
`
/opt/feather/.build/checkouts/tau-kit/Sources/TauKit/Syntax/AST.swift:306:23: error: value of type 'Date' has no member 'distance'
info.pollTime.distance(to: Date()) >= context.pollingFrequency
`
it's coming from Tau-Kit to Feather using this. Problem is on the swift foundation library side.

So I updated the swift version of docker to 5.3.3-focal as Add distance(to:) was added to Linux in this release.
https://github.com/apple/swift-corelibs-foundation/pull/2890

Tested, will fix the issue.

Thanks,

Denis